### PR TITLE
Added support for x64 DLLs, .NET Framework version 4.7 and FMO Version 1.10.

### DIFF
--- a/ConsoleTest/App.config
+++ b/ConsoleTest/App.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7"/>
     </startup>
 </configuration>

--- a/ConsoleTest/ConsoleTest.csproj
+++ b/ConsoleTest/ConsoleTest.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ConsoleTest</RootNamespace>
     <AssemblyName>ConsoleTest</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -49,6 +49,26 @@
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;X64</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>TRACE;X64</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>true</Prefer32Bit>
@@ -107,6 +127,8 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Content Include="Dependencies\x86_64\fmod64.dll" />
+    <Content Include="Dependencies\x86_64\fmodstudio64.dll" />
     <None Include="Content\Front_Center.wav">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -131,10 +153,10 @@
     <None Include="Content\Side_Right.wav">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="Dependencies\x86\fmodstudio.dll">
+    <None Include="Dependencies\x86\\**\*.dll*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="Dependencies\x86\fmod.dll">
+    <None Include="Dependencies\x86_64\\**\*.dll*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <Content Include="Dependencies\x86\Installation Note.txt" />

--- a/SupersonicSound.Test/SupersonicSound.Test.csproj
+++ b/SupersonicSound.Test/SupersonicSound.Test.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SupersonicSound.Test</RootNamespace>
     <AssemblyName>SupersonicSound.Test</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
@@ -26,6 +26,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -50,6 +51,24 @@
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>

--- a/SupersonicSound.sln
+++ b/SupersonicSound.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SupersonicSound", "SupersonicSound\SupersonicSound.csproj", "{A6A47D78-1427-4201-ADE3-F262A8F71F0A}"
 EndProject
@@ -12,33 +12,47 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{A6A47D78-1427-4201-ADE3-F262A8F71F0A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A6A47D78-1427-4201-ADE3-F262A8F71F0A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A6A47D78-1427-4201-ADE3-F262A8F71F0A}.Debug|x64.ActiveCfg = Debug|x64
+		{A6A47D78-1427-4201-ADE3-F262A8F71F0A}.Debug|x64.Build.0 = Debug|x64
 		{A6A47D78-1427-4201-ADE3-F262A8F71F0A}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{A6A47D78-1427-4201-ADE3-F262A8F71F0A}.Debug|x86.Build.0 = Debug|Any CPU
 		{A6A47D78-1427-4201-ADE3-F262A8F71F0A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A6A47D78-1427-4201-ADE3-F262A8F71F0A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A6A47D78-1427-4201-ADE3-F262A8F71F0A}.Release|x64.ActiveCfg = Release|x64
+		{A6A47D78-1427-4201-ADE3-F262A8F71F0A}.Release|x64.Build.0 = Release|x64
 		{A6A47D78-1427-4201-ADE3-F262A8F71F0A}.Release|x86.ActiveCfg = Release|x86
 		{A6A47D78-1427-4201-ADE3-F262A8F71F0A}.Release|x86.Build.0 = Release|x86
 		{6B8A9382-2DBD-4C1B-8115-7B6C08A373A8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{6B8A9382-2DBD-4C1B-8115-7B6C08A373A8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6B8A9382-2DBD-4C1B-8115-7B6C08A373A8}.Debug|x64.ActiveCfg = Debug|x64
+		{6B8A9382-2DBD-4C1B-8115-7B6C08A373A8}.Debug|x64.Build.0 = Debug|x64
 		{6B8A9382-2DBD-4C1B-8115-7B6C08A373A8}.Debug|x86.ActiveCfg = Debug|x86
 		{6B8A9382-2DBD-4C1B-8115-7B6C08A373A8}.Debug|x86.Build.0 = Debug|x86
 		{6B8A9382-2DBD-4C1B-8115-7B6C08A373A8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6B8A9382-2DBD-4C1B-8115-7B6C08A373A8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6B8A9382-2DBD-4C1B-8115-7B6C08A373A8}.Release|x64.ActiveCfg = Release|x64
+		{6B8A9382-2DBD-4C1B-8115-7B6C08A373A8}.Release|x64.Build.0 = Release|x64
 		{6B8A9382-2DBD-4C1B-8115-7B6C08A373A8}.Release|x86.ActiveCfg = Release|x86
 		{6B8A9382-2DBD-4C1B-8115-7B6C08A373A8}.Release|x86.Build.0 = Release|x86
 		{C9B1CB52-1511-4D6A-951A-B357820B07C6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C9B1CB52-1511-4D6A-951A-B357820B07C6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C9B1CB52-1511-4D6A-951A-B357820B07C6}.Debug|x64.ActiveCfg = Debug|x64
+		{C9B1CB52-1511-4D6A-951A-B357820B07C6}.Debug|x64.Build.0 = Debug|x64
 		{C9B1CB52-1511-4D6A-951A-B357820B07C6}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{C9B1CB52-1511-4D6A-951A-B357820B07C6}.Debug|x86.Build.0 = Debug|Any CPU
 		{C9B1CB52-1511-4D6A-951A-B357820B07C6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C9B1CB52-1511-4D6A-951A-B357820B07C6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C9B1CB52-1511-4D6A-951A-B357820B07C6}.Release|x64.ActiveCfg = Release|x64
+		{C9B1CB52-1511-4D6A-951A-B357820B07C6}.Release|x64.Build.0 = Release|x64
 		{C9B1CB52-1511-4D6A-951A-B357820B07C6}.Release|x86.ActiveCfg = Release|x86
 		{C9B1CB52-1511-4D6A-951A-B357820B07C6}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection

--- a/SupersonicSound/SupersonicSound.csproj
+++ b/SupersonicSound/SupersonicSound.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SupersonicSound</RootNamespace>
     <AssemblyName>SupersonicSound</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
@@ -19,7 +19,7 @@
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <DebugType>full</DebugType>
-    <PlatformTarget>AnyCPU</PlatformTarget>
+    <PlatformTarget>x64</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -56,14 +56,30 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;X64</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>TRACE;X64</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
-    <Reference Include="System.Numerics.Vectors, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Numerics.Vectors.4.1.1\lib\portable-net45+win8+wp8+wpa81\System.Numerics.Vectors.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/SupersonicSound/Wrapper/ErrorChecking.cs
+++ b/SupersonicSound/Wrapper/ErrorChecking.cs
@@ -29,17 +29,17 @@ namespace SupersonicSound.Wrapper
 
             if (throwHandle)
                 return SuppressChannelStolen;
-            if (throwStolen)
-                return SuppressInvalidHandle;
 
-            return SuppressInvalidHandleAndStolenChannel;
+            return throwStolen ? 
+                SuppressInvalidHandle 
+              : SuppressInvalidHandleAndStolenChannel;
         }
         #endregion
 
         internal static T Unbox<T>(this T? value) where T : struct
         {
             if (!value.HasValue)
-                throw new ArgumentNullException("value", "Value is null");
+                throw new ArgumentNullException(nameof(value), "Value is null");
             return value.Value;
         }
 
@@ -47,8 +47,7 @@ namespace SupersonicSound.Wrapper
         {
             if (suppress != null && suppress.Contains(result))
                 return null;
-            else
-                Check(result);
+            Check(result);
 
             return value;
         }
@@ -228,7 +227,7 @@ namespace SupersonicSound.Wrapper
                 case RESULT.ERR_NOT_LOCKED:
                     throw new FmodNotLockedException();
                 default:
-                    throw new ArgumentOutOfRangeException("result");
+                    throw new ArgumentOutOfRangeException(nameof(result));
             }
         }
     }

--- a/SupersonicSound/Wrapper/Fmod/fmod.cs
+++ b/SupersonicSound/Wrapper/Fmod/fmod.cs
@@ -16,7 +16,7 @@ namespace FMOD
     */
     public class VERSION
     {
-        public const int    number = 0x00010700;
+        public const int number = 0x00011000;
 #if X64
         public const string dll    = "fmod64";
 #else

--- a/SupersonicSound/Wrapper/Fmod/fmod.cs
+++ b/SupersonicSound/Wrapper/Fmod/fmod.cs
@@ -17,7 +17,7 @@ namespace FMOD
     public class VERSION
     {
         public const int    number = 0x00010700;
-#if WIN64
+#if X64
         public const string dll    = "fmod64";
 #else
         public const string dll    = "fmod";
@@ -1016,7 +1016,7 @@ namespace FMOD
         RECORDLISTCHANGED      = 0x00001000,  /* Called from System::update when the enumerated list of recording devices has changed. */
         ALL                    = 0xFFFFFFFF,  /* Pass this mask to System::setCallback to receive all callback types.  */
     }
-	
+    
     #region wrapperinternal
     [StructLayout(LayoutKind.Sequential)]
     public struct StringWrapper
@@ -4271,12 +4271,12 @@ namespace FMOD
         {
             byte[] bytes = new byte[builder.Capacity];
             Marshal.Copy(nativeMem, bytes, 0, builder.Capacity);
-			int strlen = Array.IndexOf(bytes, (byte)0);
-			if (strlen > 0)
-			{
-				String str = Encoding.UTF8.GetString(bytes, 0, strlen);
-				builder.Append(str);
-			}
+            int strlen = Array.IndexOf(bytes, (byte)0);
+            if (strlen > 0)
+            {
+                String str = Encoding.UTF8.GetString(bytes, 0, strlen);
+                builder.Append(str);
+            }
         }
     }
 }

--- a/SupersonicSound/Wrapper/Fmod/fmod_studio.cs
+++ b/SupersonicSound/Wrapper/Fmod/fmod_studio.cs
@@ -14,10 +14,10 @@ namespace Studio
 {
     public class STUDIO_VERSION
     {
-#if WIN64
-        public const string dll    = "fmodstudio64.dll";
+#if X64
+        public const string dll    = "fmodstudio64";
 #else
-        public const string dll    = "fmodstudio.dll";
+        public const string dll    = "fmodstudio";
 #endif
     }
 

--- a/SupersonicSound/packages.config
+++ b/SupersonicSound/packages.config
@@ -1,4 +1,3 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Numerics.Vectors" version="4.1.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
- Raised the .NET Framework version to 4.7 and fixed the duplicate declaration of Vector3 issue. 

- Added support for loading x64 DLLs and added CopyToOutputDirectory wildcard for all DLLs in Dependency folders.

- Raised the FMOD version number to the latest, 1.10.00